### PR TITLE
fix travis warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 os: linux
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os: linux
 dist: xenial
+language: generic
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: linux
+dist: xenial
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ The Potassco guide provides an introduction to the Answer Set Programming tools 
 
 This guide, for one, aims at enabling ASP novices to make use of the aforementioned tools.
 For another, it provides a reference of the tools' features that ASP adepts might be tempted to exploit.
+
+
+## How to Build
+
+see file `.travis.yml` for a list of build-dependencies and how to build
+the guide.


### PR DESCRIPTION
Reading the sourcecode of potassco/guide.git i noticed some warnings regarding the .travis.yml file.
This Pull-Request

* solves 3 warnings issued by travis-ci
* documents in README.md, that the .travis.yml file is the authoritative source for list of build dependencies.

All changes in this pull request are expected to have no effect on the file `guide.pdf`actually generated.