### PR TITLE
WIP: document build steps in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 os: linux
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ addons:
 
 script:
   - pdflatex -interaction nonstopmode guide.tex
+  - bibtex guide
+  - pdflatex -interaction nonstopmode guide.tex
+  - pdflatex -interaction nonstopmode guide.tex
+  - zip -r examples.zip examples/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os: linux
 dist: xenial
+language: generic
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: linux
+dist: xenial
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ The Potassco guide provides an introduction to the Answer Set Programming tools 
 
 This guide, for one, aims at enabling ASP novices to make use of the aforementioned tools.
 For another, it provides a reference of the tools' features that ASP adepts might be tempted to exploit.
+
+
+## How to Build
+
+see file `.travis.yml` for a list of build-dependencies and how to build
+the guide.


### PR DESCRIPTION
Pre-Script: This pull request is based on https://github.com/potassco/guide/pull/28 and thus WIP until that one has been adjudicated.

In addition to https://github.com/potassco/guide/pull/28 i would propose to document the build steps necessary to generate the release files 'guide.pdf' and 'examples.zip' in travis.yml.
- Advantage in the short time is higher reproducibility of build by third parties.
- In the long term, building release files and uploading them to a github tag via travis might be considered.

As a disadvantage of note is, that the cpu-workload onto travis is increased by the commits in this pull-request, and thus available credits at travis-ci has to be considered before merging.

with kind regards,
Max